### PR TITLE
Handle empty sheets

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const KEY_VALUE_TYPE = 'kv';
 const KEY_VALUE_RANGE = '!A:B';
 const SKIP_TYPE = 'skip';
 
-function zipObject(keys, values) {
+function zipObject(keys = [], values) {
   const result = {};
 
   keys.forEach((key, i) => {
@@ -21,7 +21,7 @@ function zipObject(keys, values) {
   return result;
 }
 
-function valuesToObject(rows) {
+function valuesToObject(rows = []) {
   const headers = rows[0];
 
   return rows.slice(1).map(values => zipObject(headers, values));

--- a/tests/expected/output.js
+++ b/tests/expected/output.js
@@ -40,4 +40,6 @@ module.exports = {
       column3: 'value9',
     },
   ],
+  tabular_empty: [],
+  keyvalue_empty: {},
 };


### PR DESCRIPTION
Succeed in parsing empty sheets, returning the empty representation of
an empty array (`[]`) for a tabular sheet and an empty object (`{}`) for
a key-value sheet.

Add expectation of two empty sheets named `tabular_empty` and
`keyvalue_empty:kv` in the test sheet.